### PR TITLE
Set line numbers, get rid of annoying go warning message

### DIFF
--- a/vimrcs/basic.vim
+++ b/vimrcs/basic.vim
@@ -46,6 +46,9 @@
 " Sets how many lines of history VIM has to remember
 set history=500
 
+" Sets Line Numbers
+set number
+
 " Enable filetype plugins
 filetype plugin on
 filetype indent on

--- a/vimrcs/plugins_config.vim
+++ b/vimrcs/plugins_config.vim
@@ -132,7 +132,7 @@ nnoremap <silent> <leader>z :Goyo<cr>
 " => Vim-go
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 let g:go_fmt_command = "goimports"
-
+let g:go_version_warning = 0
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Syntastic (syntax checker)


### PR DESCRIPTION
- Set line numbers
- Get rid of the vim-go plugin warning message that occurs on a fresh install of vimrc in 'awesome' mode.